### PR TITLE
Fix Safari alignment issue for text size controls

### DIFF
--- a/Culture.html
+++ b/Culture.html
@@ -29,17 +29,17 @@
                     <a href="Walks.html" class="nav-link" data-lang-key="navWalks">Leichte Wanderungen</a>
                 </nav>
                 <div class="header-controls">
-                    <div class="size-switcher">
+                    <div class="text-size-toggle">
                         <button id="increase-text" aria-label="Textgröße erhöhen" title="Textgröße erhöhen" class="text-size-button">
                             <svg xmlns="http://www.w3.org/2000/svg" class="control-button-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4M18 12h2m-4-4V6m0 12v2M6 12H4m4 4v2m0-12V6" /></svg> A+
                         </button>
                         <button id="decrease-text" aria-label="Textgröße verringern" title="Textgröße verringern" class="text-size-button">
                             <svg xmlns="http://www.w3.org/2000/svg" class="control-button-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4M18 12h2m-4-4V6m0 12v2M6 12H4m4 4v2m0-12V6" /></svg> A-
                         </button>
+                        <button id="language-switch" aria-label="Sprache wechseln" title="Sprache wechseln" class="lang-switch-button">
+                            EN
+                        </button>
                     </div>
-                    <button id="language-switch" aria-label="Sprache wechseln" title="Sprache wechseln" class="lang-switch-button">
-                        EN
-                    </button>
                 </div>
                 <div class="mobile-menu-toggle-container">
                     <button id="language-switch-mobile" aria-label="Sprache wechseln" title="Sprache wechseln" class="lang-switch-button-mobile">

--- a/Walks.html
+++ b/Walks.html
@@ -29,17 +29,17 @@
                     <a href="Walks.html" class="nav-link" data-lang-key="navWalks">Leichte Wanderungen</a>
                 </nav>
                 <div class="header-controls">
-                    <div class="size-switcher">
+                    <div class="text-size-toggle">
                         <button id="increase-text" aria-label="Textgröße erhöhen" title="Textgröße erhöhen" class="text-size-button">
                             <svg xmlns="http://www.w3.org/2000/svg" class="control-button-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4M18 12h2m-4-4V6m0 12v2M6 12H4m4 4v2m0-12V6" /></svg> A+
                         </button>
                         <button id="decrease-text" aria-label="Textgröße verringern" title="Textgröße verringern" class="text-size-button">
                             <svg xmlns="http://www.w3.org/2000/svg" class="control-button-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4M18 12h2m-4-4V6m0 12v2M6 12H4m4 4v2m0-12V6" /></svg> A-
                         </button>
+                        <button id="language-switch" aria-label="Sprache wechseln" title="Sprache wechseln" class="lang-switch-button">
+                            EN
+                        </button>
                     </div>
-                    <button id="language-switch" aria-label="Sprache wechseln" title="Sprache wechseln" class="lang-switch-button">
-                        EN
-                    </button>
                 </div>
                 <div class="mobile-menu-toggle-container">
                     <button id="language-switch-mobile" aria-label="Sprache wechseln" title="Sprache wechseln" class="lang-switch-button-mobile">

--- a/Wellness.html
+++ b/Wellness.html
@@ -29,17 +29,17 @@
                     <a href="Walks.html" class="nav-link" data-lang-key="navWalks">Leichte Wanderungen</a>
                 </nav>
                 <div class="header-controls">
-                    <div class="size-switcher">
+                    <div class="text-size-toggle">
                         <button id="increase-text" aria-label="Textgröße erhöhen" title="Textgröße erhöhen" class="text-size-button">
                             <svg xmlns="http://www.w3.org/2000/svg" class="control-button-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4M18 12h2m-4-4V6m0 12v2M6 12H4m4 4v2m0-12V6" /></svg> A+
                         </button>
                         <button id="decrease-text" aria-label="Textgröße verringern" title="Textgröße verringern" class="text-size-button">
                             <svg xmlns="http://www.w3.org/2000/svg" class="control-button-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4M18 12h2m-4-4V6m0 12v2M6 12H4m4 4v2m0-12V6" /></svg> A-
                         </button>
+                        <button id="language-switch" aria-label="Sprache wechseln" title="Sprache wechseln" class="lang-switch-button">
+                            EN
+                        </button>
                     </div>
-                    <button id="language-switch" aria-label="Sprache wechseln" title="Sprache wechseln" class="lang-switch-button">
-                        EN
-                    </button>
                 </div>
                 <div class="mobile-menu-toggle-container">
                     <button id="language-switch-mobile" aria-label="Sprache wechseln" title="Sprache wechseln" class="lang-switch-button-mobile">

--- a/index.html
+++ b/index.html
@@ -29,17 +29,17 @@
                     <a href="Walks.html" class="nav-link" data-lang-key="navWalks">Leichte Wanderungen</a>
                 </nav>
                 <div class="header-controls">
-                    <div class="size-switcher">
+                    <div class="text-size-toggle">
                         <button id="increase-text" aria-label="Textgröße erhöhen" title="Textgröße erhöhen" class="text-size-button">
                             <svg xmlns="http://www.w3.org/2000/svg" class="control-button-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4M18 12h2m-4-4V6m0 12v2M6 12H4m4 4v2m0-12V6" /></svg> A+
                         </button>
                         <button id="decrease-text" aria-label="Textgröße verringern" title="Textgröße verringern" class="text-size-button">
                             <svg xmlns="http://www.w3.org/2000/svg" class="control-button-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4M18 12h2m-4-4V6m0 12v2M6 12H4m4 4v2m0-12V6" /></svg> A-
                         </button>
+                        <button id="language-switch" aria-label="Sprache wechseln" title="Sprache wechseln" class="lang-switch-button">
+                            EN
+                        </button>
                     </div>
-                    <button id="language-switch" aria-label="Sprache wechseln" title="Sprache wechseln" class="lang-switch-button">
-                        EN
-                    </button>
                 </div>
                 <div class="mobile-menu-toggle-container">
                     <button id="language-switch-mobile" aria-label="Sprache wechseln" title="Sprache wechseln" class="lang-switch-button-mobile">

--- a/style.css
+++ b/style.css
@@ -344,53 +344,45 @@ h4 {
         margin: auto;
     }
 }
-.size-switcher  {
+.text-size-toggle {
     position: relative;
     z-index: 50;
-    justify-content: space-around;
-    align-items: center;
-    width: 80px;
-    border-style: solid;
-    border-radius: 40px;
-    height: 48px;
-    border-color: #056599;
     display: flex;
+    align-items: center;
+    justify-content: space-around;
+    width: 80px;
+    height: 48px;
+    border: 1px solid #056599;
+    border-radius: 40px;
 }
 @media (max-width: 640px) {
-    .size-switcher {
-        display: flex;
-        align-items: center;
-        height: 48px;
+    .text-size-toggle {
         width: 120px;
-        z-index: 40;
+        height: 48px;
     }
-    .size-switcher svg {
+    .text-size-toggle svg {
         width: 32px;
         height: 32px;
-        display: flex;
+        display: block;
     }
 }
 @media (min-width: 768px) and (max-width: 1366px) {
-    .size-switcher {
-        display: flex;
-        align-items: center;
-        height: 48px;
+    .text-size-toggle {
         width: 120px;
-        z-index: 40;
+        height: 48px;
     }
-    .size-switcher svg {
+    .text-size-toggle svg {
         width: 32px;
         height: 32px;
-        display: flex;
+        display: block;
     }
 }
 
 .text-size-button {
     display: flex;
-    flex-direction: column;
-    font-size: 18px;
-    justify-content: center;
     align-items: center;
+    justify-content: center;
+    font-size: 18px;
     height: 100%;
     border-radius: 9999px;
     color: #056599;
@@ -403,24 +395,25 @@ h4 {
     -webkit-appearance: none;
     appearance: none;
     cursor: pointer;
+    line-height: 1;
+    vertical-align: middle;
 }
 
 .lang-switch-button {
     display: flex;
-    flex-direction: row;
     align-items: center;
     justify-content: center;
     font-size: 18px;
     color: #056599;
-    font-weight: 600; 
+    font-weight: 600;
     transition-property: background-color;
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-    transition-duration: 150ms; 
+    transition-duration: 150ms;
     background-color: transparent;
     border: transparent;
     cursor: pointer;
-
-
+    line-height: 1;
+    vertical-align: middle;
 }
 @media (max-width: 1330px) {
     .lang-switch-button{
@@ -515,20 +508,15 @@ h4 {
 }
 
 .control-button-icon {
-    display: flex;
-    align-content: end;
-    justify-content: end;
+    display: block;
     margin: 0;
-    height: 100%; 
-    width: 20px; 
+    height: 20px;
+    width: 20px;
 }
-@media (min-width: 640px) { 
+@media (min-width: 640px) {
     .control-button-icon {
-        display: flex;
-        align-items: end;
-        justify-content: center;
-        height: 20px; 
-        width: max-content;
+        height: 20px;
+        width: 20px;
     }
 }
 


### PR DESCRIPTION
## Summary
- wrap text size and language controls in `.text-size-toggle`
- replace old `.size-switcher` styles and improve vertical centering
- adjust button and icon CSS for consistent alignment

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841840b74e8833389c27edde2ee4a4a